### PR TITLE
Replace prepare with prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "scripts": {
         "build-types": "tsc --emitDeclarationOnly && sed -i 's/export = SuperMap;/\\/\\/@ts-expect-error\\n&/' index.d.ts",
         "build": "npx swc index.ts -o index.js -C jsc.target=es2022 -C module.type=commonjs && pnpm build-types",
-        "prepare": "pnpm build",
+        "prepublishOnly": "pnpm build",
         "prepack": "pnpm build"
     }
 }


### PR DESCRIPTION
The "prepare" script is run not only when the package is published, but also when it is *installed*. This means that it'll try to build the package on the machine of whoever installs it, which sometimes fails. "prepublishOnly" scripts are only run when publishing the package, which is what you probably want for running build scripts.